### PR TITLE
Added missing dependencies to readme (for ubuntu)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Dependencies
 ------------
 On Ubuntu::
 
-    $ sudo apt-get install libssl-dev libffi-dev libtool python-dev autoconf
+    $ sudo apt-get install libssl-dev libffi-dev libtool python-dev autoconf automake
 
 
 Installation

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,11 @@ Dependencies
 ------------
 On Ubuntu::
 
+    # install dependencies
     $ sudo apt-get install libssl-dev libffi-dev libtool python-dev autoconf automake
+
+    # test dependencies
+    $ sudo apt-get install python-tox
 
 
 Installation


### PR DESCRIPTION
To install on ubuntu `automake` is required and to test `python-tox`, I updated the readme accordingly.